### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "prysm-medalla-validator.dnp.dappnode.eth",
   "version": "1.0.9",
-  "upstreamVersion": "v1.0.0-beta.0",
+  "upstreamVersion": "v1.0.0-beta.1",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm Medalla ETH2.0 Validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
-version: '3.4'
+version: "3.4"
 services:
   prysm-medalla-validator.dnp.dappnode.eth:
-    image: 'prysm-medalla-validator.dnp.dappnode.eth:1.0.9'
+    image: "prysm-medalla-validator.dnp.dappnode.eth:1.0.9"
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v1.0.0-beta.0
+        UPSTREAM_VERSION: v1.0.0-beta.1
     volumes:
-      - 'data:/root/'
+      - "data:/root/"
     restart: always
     environment:
-      BEACON_RPC_PROVIDER: 'prysm-medalla-beacon-chain.dappnode:4000'
-      BEACON_RPC_GATEWAY_PROVIDER: 'prysm-medalla-beacon-chain.dappnode:3500'
+      BEACON_RPC_PROVIDER: "prysm-medalla-beacon-chain.dappnode:4000"
+      BEACON_RPC_GATEWAY_PROVIDER: "prysm-medalla-beacon-chain.dappnode:3500"
       GRAFFITI: validating_from_DAppNode
-      EXTRA_OPTS: ''
-      WALLET_PASSWORD: ''
+      EXTRA_OPTS: ""
+      WALLET_PASSWORD: ""
 volumes:
   data: {}
   validators: {}


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.0 to [v1.0.0-beta.1](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.1)