### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "prysm-medalla-validator.dnp.dappnode.eth",
   "version": "1.0.9",
-  "upstreamVersion": "v1.0.0-beta.1",
+  "upstreamVersion": "v1.0.0-beta.2",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm Medalla ETH2.0 Validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v1.0.0-beta.1
+        UPSTREAM_VERSION: v1.0.0-beta.2
     volumes:
       - "data:/root/"
     restart: always


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.1 to [v1.0.0-beta.2](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.2)